### PR TITLE
Filter technicians by status in retrieval logic

### DIFF
--- a/el7erafe.Web/Core/Service/AdminDashboardService.cs
+++ b/el7erafe.Web/Core/Service/AdminDashboardService.cs
@@ -381,8 +381,8 @@ namespace Service
                     pageNumber.HasValue && pageSize.HasValue);
 
                 IEnumerable<Technician>? technicians = pageNumber.HasValue
-                    ? await technicianRepository.GetPagedAsync(pageNumber.Value, pageSize.Value)
-                    : await technicianRepository.GetAllAsync();
+                    ? await technicianRepository.GetPagedByStatusAsync(TechnicianStatus.Accepted, pageNumber.Value, pageSize.Value)
+                    : await technicianRepository.GetAllByStatusAsync(TechnicianStatus.Accepted);
 
                 logger.LogInformation("[SERVICE] Successfully retrieved Technicians from repository. Technician count: {TechnicianCount}",
                     technicians?.Count() ?? 0);


### PR DESCRIPTION
Updated the technician retrieval logic in `AdminDashboardService.cs` to ensure only technicians with the `TechnicianStatus.Accepted` status are fetched. Modified the repository calls to use `GetPagedByStatusAsync` for paginated results and
`GetAllByStatusAsync` for non-paginated results. This change ensures consistent filtering by status regardless of pagination.