### PR TITLE
Refactor offer retrieval logic and unify client endpoints

### DIFF
--- a/el7erafe.Web/Core/DomainLayer/Contracts/IOffersRepository.cs
+++ b/el7erafe.Web/Core/DomainLayer/Contracts/IOffersRepository.cs
@@ -7,8 +7,7 @@ namespace DomainLayer.Contracts
         Task<Offer> AddOfferAsync(Offer offer);
 
         Task<bool> HasTechnicianAlreadyOffered(int technicianId, int requestId);
-        Task<IEnumerable<Offer>> GetValidQuickOffersForClientAsync(int serReqId, int clientId);
-        Task<IEnumerable<Offer>> GetValidTechOfferForClientsAsync(int serReqId, int clientId);
+        Task<IEnumerable<Offer>> GetValidOffersForClientAsync(int serReqId, int clientId, bool isQuick);
         Task<bool> HasTimeConflict(int technicianId, TimeOnly fromTime, TimeOnly toTime, DateOnly serviceDate, int? numberOfDays);
     }
 }

--- a/el7erafe.Web/Core/Service/ClientService.cs
+++ b/el7erafe.Web/Core/Service/ClientService.cs
@@ -527,100 +527,20 @@ namespace Service
             }
         }
 
-        public async Task<List<OfferResultDto>> GetQuickOffersAsync(string userId, ReqIdDTO reqIdDTO)
-        {
-            var user = await CheckUser(userId);
-
-            try
-            {
-
-                var validOffers = await offersRepository.GetValidQuickOffersForClientAsync(reqIdDTO.requestId, user.Id);
-
-                if (!validOffers.Any())
-                    return new List<OfferResultDto>();
-
-                var mappingTasks = validOffers.Select(async offer =>
-                {
-                    string techImageUrl = string.Empty;
-                    if (!string.IsNullOrWhiteSpace(offer.Technician?.ProfilePictureURL))
-                    {
-                        techImageUrl = await blobStorageRepository.GetBlobUrlWithSasTokenAsync("technician-documents", offer.Technician.ProfilePictureURL);
-                    }
-
-                    return new OfferResultDto
-                    {
-                        OfferId = offer.Id,
-                        RequestId = offer.ServiceRequestId,
-
-                        TechName = offer.Technician?.Name ?? "فني",
-                        TechImage = techImageUrl,
-                        NumberOfSuccessJobs = 0, // will do later
-                        Rate = offer.Technician?.Rating ?? 0,
-
-                        ServiceType = offer.ServiceRequest?.Service?.NameAr ?? "غير معروف",
-                        Fees = offer.Fees,
-                        FromTime = offer.WorkFrom,
-                        ToTime = offer.WorkTo,
-                        Day = offer.ServiceRequest.ServiceDate,
-                        NumberOfDays = offer.NumberOfDays,
-                        Comments = null,
-
-                        ClientId = offer.ServiceRequest.ClientId
-                    };
-                });
-
-                return (await Task.WhenAll(mappingTasks)).ToList();
-            }
-            catch (Exception)
-            {
-                throw new TechnicalException();
-            }
-        }
-
-        public async Task<List<OfferResultDto>> GetTechReserveOffersAsync(string userId, ReqIdDTO reqIdDTO)
+        public async Task<List<OfferResultDto>> GetOffersAsync(string userId, int requestId, bool isQuick)
         {
             var client = await CheckUser(userId);
 
             try
             {
-                var validOffers = await offersRepository.GetValidTechOfferForClientsAsync(reqIdDTO.requestId, client.Id);
+                var validOffers = await offersRepository.GetValidOffersForClientAsync(requestId, client.Id, isQuick);
 
                 if (!validOffers.Any())
                     return new List<OfferResultDto>();
 
-                var mappingTasks = validOffers.Select(async offer =>
-                {
-                    string techImageUrl = string.Empty;
-                    if (!string.IsNullOrWhiteSpace(offer.Technician?.ProfilePictureURL))
-                    {
-                        techImageUrl = await blobStorageRepository.GetBlobUrlWithSasTokenAsync("technician-documents", offer.Technician.ProfilePictureURL);
-                    }
-
-                    return new OfferResultDto
-                    {
-                        OfferId = offer.Id,
-                        RequestId = offer.ServiceRequestId,
-
-                        TechName = offer.Technician?.Name ?? "فني",
-                        TechImage = techImageUrl,
-                        NumberOfSuccessJobs = 0, // will do later
-                        Rate = offer.Technician?.Rating ?? 0,
-
-                        ServiceType = offer.ServiceRequest?.Service?.NameAr ?? "غير معروف",
-                        Fees = offer.Fees,
-                        FromTime = offer.WorkFrom,
-                        ToTime = offer.WorkTo,
-                        Day = offer.ServiceRequest.ServiceDate,
-                        NumberOfDays = offer.NumberOfDays,
-                        Comments = null,
-
-                        ClientId = offer.ServiceRequest.ClientId
-                    };
-                });
-
-                return (await Task.WhenAll(mappingTasks)).ToList();
+                return (await Task.WhenAll(validOffers.Select(MapOffer))).ToList();
             }
-            catch (Exception)
+            catch
             {
                 throw new TechnicalException();
             }
@@ -690,6 +610,35 @@ namespace Service
             {
                 return new Dictionary<string, string>();
             }
+        }
+        private async Task<OfferResultDto> MapOffer(Offer offer)
+        {
+            string techImageUrl = string.Empty;
+
+            if (!string.IsNullOrWhiteSpace(offer.Technician?.ProfilePictureURL))
+            {
+                techImageUrl = await blobStorageRepository.GetBlobUrlWithSasTokenAsync("technician-documents",offer.Technician.ProfilePictureURL);
+            }
+
+            return new OfferResultDto
+            {
+                OfferId = offer.Id,
+                RequestId = offer.ServiceRequestId,
+
+                TechName = offer.Technician?.Name ?? "فني",
+                TechImage = techImageUrl,
+                NumberOfSuccessJobs = 0,
+                Rate = offer.Technician?.Rating ?? 0,
+
+                ServiceType = offer.ServiceRequest?.Service?.NameAr ?? "غير معروف",
+                Fees = offer.Fees,
+                TechTimeInterval = HelperClass.FormatArabicTimeInterval(offer.WorkFrom, offer.WorkTo),
+                Day = offer.ServiceRequest.ServiceDate,
+                NumberOfDays = offer.NumberOfDays,
+                Comments = null,
+
+                ClientId = offer.ServiceRequest.ClientId
+            };
         }
 
     }

--- a/el7erafe.Web/Core/Service/OfferService.cs
+++ b/el7erafe.Web/Core/Service/OfferService.cs
@@ -1,6 +1,7 @@
 ﻿using DomainLayer.Contracts;
 using DomainLayer.Exceptions;
 using DomainLayer.Models;
+using Service.Helpers;
 using ServiceAbstraction;
 using Shared.DataTransferObject.OffersDTOs;
 
@@ -65,8 +66,7 @@ namespace Service
                 TechImage = await blobStorageRepository.GetBlobUrlWithSasTokenAsync("technician-documents",technician.ProfilePictureURL),
                 Rate = technician.Rating,
                 Fees = offer.Fees,
-                FromTime = offer.WorkFrom.Value,
-                ToTime = offer.WorkTo.Value,
+                TechTimeInterval = HelperClass.FormatArabicTimeInterval(offer.WorkFrom, offer.WorkTo),
                 NumberOfDays = offer.NumberOfDays,
                 ClientId = request.ClientId
             };

--- a/el7erafe.Web/Core/ServiceAbstraction/IClientService.cs
+++ b/el7erafe.Web/Core/ServiceAbstraction/IClientService.cs
@@ -1,5 +1,4 @@
-﻿
-using DomainLayer.Models.IdentityModule;
+﻿using DomainLayer.Models.IdentityModule;
 using Shared.DataTransferObject.ClientDTOs;
 using Shared.DataTransferObject.ClientIdentityDTOs;
 using Shared.DataTransferObject.OffersDTOs;
@@ -16,8 +15,7 @@ namespace ServiceAbstraction
         Task<List<ServiceRequestDTO>> GetPendingServiceRequestsAsync(string userId);
         Task DeleteAccount(string userId);
         Task<ClientProfileDTO> GetProfileAsync(string userId);
-        Task<List<OfferResultDto>> GetTechReserveOffersAsync(string userId, ReqIdDTO reqIdDTO);
-        Task<List<OfferResultDto>> GetQuickOffersAsync(string userId, ReqIdDTO reqIdDTO);
+        Task<List<OfferResultDto>> GetOffersAsync(string userId, int requestId, bool isQuick);
         Task<List<AvailableTechnicianDto>> GetAvailableTechniciansAsync(GetAvailableTechniciansRequest requestRegDTO);
         Task UpdateNameAndImage(string userId, UpdateNameImageDTO dTO);
         Task UpdatePhoneNumber(string userId, UpdatePhoneDTO dTO);

--- a/el7erafe.Web/Infrastructure/Persistance/Repositories/OffersRepository.cs
+++ b/el7erafe.Web/Infrastructure/Persistance/Repositories/OffersRepository.cs
@@ -24,21 +24,7 @@ namespace Persistance.Repositories
                     o.ServiceRequestId == requestId);
         }
 
-        public async Task<IEnumerable<Offer>> GetValidQuickOffersForClientAsync(int serReqId, int clientId)
-        {
-            return await dbContext.Set<Offer>()
-                .Include(o => o.Technician)
-                .Include(o => o.ServiceRequest)
-                    .ThenInclude(sr => sr.Service)
-                .Where(o =>
-                    o.ServiceRequestId == serReqId &&
-                    o.ServiceRequest.ClientId == clientId && 
-                    o.ServiceRequest.Status == ServiceReqStatus.Pending
-                    && o.ServiceRequest.TechnicianId == null)
-                .ToListAsync();
-        }
-
-        public async Task<IEnumerable<Offer>> GetValidTechOfferForClientsAsync(int serReqId, int clientId)
+        public async Task<IEnumerable<Offer>> GetValidOffersForClientAsync(int serReqId, int clientId, bool isQuick)
         {
             return await dbContext.Set<Offer>()
                 .Include(o => o.Technician)
@@ -47,8 +33,10 @@ namespace Persistance.Repositories
                 .Where(o =>
                     o.ServiceRequestId == serReqId &&
                     o.ServiceRequest.ClientId == clientId &&
-                    o.ServiceRequest.Status == ServiceReqStatus.Pending
-                    && o.ServiceRequest.TechnicianId != null)
+                    o.ServiceRequest.Status == ServiceReqStatus.Pending &&
+                    (isQuick
+                        ? o.ServiceRequest.TechnicianId == null
+                        : o.ServiceRequest.TechnicianId != null))
                 .ToListAsync();
         }
 

--- a/el7erafe.Web/Infrastructure/Presentation/Controllers/ClientController.cs
+++ b/el7erafe.Web/Infrastructure/Presentation/Controllers/ClientController.cs
@@ -220,7 +220,7 @@ namespace Presentation.Controllers
             return Ok(result);
         }
 
-        [HttpGet("cf/getquickoffers")]
+        [HttpGet("cf/offers/quick")]
         public async Task<IActionResult> GetQuickOffers(ReqIdDTO reqIdDTO)
         {
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
@@ -228,10 +228,10 @@ namespace Presentation.Controllers
             if (string.IsNullOrEmpty(userId))
                 return Unauthorized();
 
-            return Ok(await _clientService.GetQuickOffersAsync(userId, reqIdDTO));
+            return Ok(await _clientService.GetOffersAsync(userId, reqIdDTO.requestId, true));
         }
 
-        [HttpGet("cf/gettechoffers")]
+        [HttpGet("cf/offers/specific")]
         public async Task<IActionResult> GetTechOffers(ReqIdDTO reqIdDTO)
         {
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
@@ -239,7 +239,7 @@ namespace Presentation.Controllers
             if (string.IsNullOrEmpty(userId))
                 return Unauthorized();
 
-            return Ok(await _clientService.GetTechReserveOffersAsync(userId, reqIdDTO));
+            return Ok(await _clientService.GetOffersAsync(userId, reqIdDTO.requestId, false));
         }
     }
 }

--- a/el7erafe.Web/Shared/DataTransferObject/OffersDTOs/OfferResultDto.cs
+++ b/el7erafe.Web/Shared/DataTransferObject/OffersDTOs/OfferResultDto.cs
@@ -9,17 +9,15 @@ namespace Shared.DataTransferObject.OffersDTOs
 
         public int RequestId { get; set; }
 
-        public string? TechName { get; set; } = default!;
+        public string? TechName { get; set; }
 
-        public string? TechImage { get; set; } = default!;
+        public string? TechImage { get; set; }
 
-        public string? ServiceType { get; set; } = default!;
+        public string? ServiceType { get; set; }
 
         public decimal? Fees { get; set; }
 
-        public TimeOnly? FromTime { get; set; }
-
-        public TimeOnly? ToTime { get; set; }
+        public string? TechTimeInterval { get; set; }
 
         public DateOnly? Day { get; set; }
 
@@ -27,7 +25,7 @@ namespace Shared.DataTransferObject.OffersDTOs
 
         public decimal? Rate { get; set; }
 
-        public string? Comments { get; set; } = default!;
+        public string? Comments { get; set; }
 
         public int? NumberOfDays { get; set; }
 


### PR DESCRIPTION
- Consolidate quick and specific offer retrieval into GetOffersAsync/GetValidOffersForClientAsync with isQuick flag
- Replace FromTime/ToTime with TechTimeInterval in OfferResultDto
- Update controller endpoints to /cf/offers/quick and /cf/offers/specific
- Extract Offer-to-DTO mapping to a reusable method
- Remove redundant code and improve maintainability