### PR TITLE
Add client offer decline functionality and related API

### DIFF
--- a/el7erafe.Web/Core/DomainLayer/Contracts/IOffersRepository.cs
+++ b/el7erafe.Web/Core/DomainLayer/Contracts/IOffersRepository.cs
@@ -12,5 +12,6 @@ namespace DomainLayer.Contracts
         Task<List<Offer>> GetPendingOffersForTechAsync(int technicianId);
         Task<List<string>> GetRejectedTechnicianUserIds(int requestId, int acceptedOfferId);
         Task RejectOtherOffers(int requestId, int acceptedOfferId);
+        Task RejectOfferAsync(int offerId);
     }
 }

--- a/el7erafe.Web/Core/Service/ClientService.cs
+++ b/el7erafe.Web/Core/Service/ClientService.cs
@@ -586,28 +586,28 @@ namespace Service
             var existing = await reservationRepository.GetByOfferIdAsync(offerId);
 
             if (existing != null)
-                throw new Exception("Offer already accepted");
+                throw new Exception("تم قبول هذا العرض بالفعل");
 
             var offer = await offersRepository.GetByIdAsync(offerId);
 
             if (offer == null)
-                throw new Exception("Offer not found");
+                throw new Exception("لم يتم العثور على العرض");
 
             var request = await serviceRequestRepository.GetServiceById(offer.ServiceRequestId);
 
             if (request == null)
-                throw new Exception("Service request not found");
+                throw new Exception("لم يتم العثور على طلب الخدمة");
 
             if (request.Status != ServiceReqStatus.Pending)
-                throw new Exception("Service request already reserved");
+                throw new Exception("تم حجز طلب الخدمة بالفعل");
 
-            // Update service request status
             request.Status = ServiceReqStatus.Reserved;
             offer.Status = OfferStatus.Accepted;
 
+            var rejectedTechIds = await offersRepository.GetRejectedTechnicianUserIds(request.Id, offer.Id);
+
             await offersRepository.RejectOtherOffers(offer.ServiceRequestId, offer.Id);
 
-            // Create reservation
             var reservation = new Reservation
             {
                 OfferId = offer.Id,
@@ -618,7 +618,6 @@ namespace Service
             await reservationRepository.SaveChangesAsync();
 
             var acceptedTechUserId = offer.Technician.UserId;
-            var rejectedTechIds = await offersRepository.GetRejectedTechnicianUserIds(request.Id, offer.Id);
 
             return new AcceptOfferResultDto
             {
@@ -626,6 +625,26 @@ namespace Service
                 AcceptedOfferId = offer.Id,
                 AcceptedTechnicianUserId = acceptedTechUserId,
                 RejectedTechnicianUserIds = rejectedTechIds
+            };
+        }
+
+        public async Task<DeclineOfferResultDto> DeclineOffer(int offerId)
+        {
+            var offer = await offersRepository.GetByIdAsync(offerId);
+
+            if (offer == null)
+                throw new Exception("لم يتم العثور على العرض");
+
+            if (offer.Status != OfferStatus.Pending)
+                throw new Exception("لا يمكن تنفيذ العملية، العرض لم يعد قيد الانتظار");
+
+            await offersRepository.RejectOfferAsync(offerId);
+
+            return new DeclineOfferResultDto
+            {
+                RequestId = offer.ServiceRequestId,
+                OfferId = offer.Id,
+                TechnicianUserId = offer.Technician.UserId
             };
         }
 

--- a/el7erafe.Web/Core/ServiceAbstraction/IClientService.cs
+++ b/el7erafe.Web/Core/ServiceAbstraction/IClientService.cs
@@ -25,5 +25,6 @@ namespace ServiceAbstraction
         Task<OtpResponseDTO> ResendOtpForPendingEmail(string userId);
         Task<Client?> GetClientByIdAsync(int clientId);
         Task<AcceptOfferResultDto> AcceptOffer(int offerId);
+        Task<DeclineOfferResultDto> DeclineOffer(int offerId);
     }
 }

--- a/el7erafe.Web/Infrastructure/Persistance/Repositories/OffersRepository.cs
+++ b/el7erafe.Web/Infrastructure/Persistance/Repositories/OffersRepository.cs
@@ -87,7 +87,7 @@ namespace Persistance.Repositories
             return await dbContext.Offers
                 .Where(o => o.ServiceRequestId == requestId
                             && o.Id != acceptedOfferId
-                            && o.Status == OfferStatus.Rejected)
+                            && o.Status == OfferStatus.Pending)
                 .Select(o => o.Technician.UserId)
                 .Distinct()
                 .ToListAsync();
@@ -99,6 +99,17 @@ namespace Persistance.Repositories
                 .Where(o => o.ServiceRequestId == requestId && o.Id != acceptedOfferId)
                 .ExecuteUpdateAsync(setters => setters
                     .SetProperty(o => o.Status, OfferStatus.Rejected));
+        }
+
+        public async Task RejectOfferAsync(int offerId)
+        {
+            var affected = await dbContext.Offers
+                .Where(o => o.Id == offerId && o.Status == OfferStatus.Pending)
+                .ExecuteUpdateAsync(setters => setters
+                    .SetProperty(o => o.Status, OfferStatus.Rejected));
+
+            if (affected == 0)
+                throw new Exception("Offer not found or not pending");
         }
     }
 }

--- a/el7erafe.Web/Infrastructure/Presentation/Controllers/ClientController.cs
+++ b/el7erafe.Web/Infrastructure/Presentation/Controllers/ClientController.cs
@@ -271,5 +271,24 @@ namespace Presentation.Controllers
 
             return Ok(new { message = "تم قبول العرض بنجاح" });
         }
+
+        [HttpPost("cf/offers/decline")]
+        public async Task<IActionResult> DeclineOffer([FromBody] OfferIdDto dto)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrEmpty(userId))
+                return Unauthorized("المستخدم غير موجود");
+
+            var result = await _clientService.DeclineOffer(dto.offerId);
+
+            await technicianHub.Clients.User(result.TechnicianUserId)
+                .SendAsync("OfferRejected", new
+                {
+                    requestId = result.RequestId,
+                    offerId = result.OfferId
+                });
+
+            return Ok(new { message = "تم رفض العرض بنجاح" });
+        }
     }
 }

--- a/el7erafe.Web/Shared/DataTransferObject/OffersDTOs/DeclineOfferResultDto.cs
+++ b/el7erafe.Web/Shared/DataTransferObject/OffersDTOs/DeclineOfferResultDto.cs
@@ -1,0 +1,12 @@
+﻿
+namespace Shared.DataTransferObject.OffersDTOs
+{
+    public class DeclineOfferResultDto
+    {
+        public int RequestId { get; set; }
+
+        public int OfferId { get; set; }
+
+        public string TechnicianUserId { get; set; } = default!;
+    }
+}


### PR DESCRIPTION
Clients can now decline (reject) offers in addition to accepting them.
- Added RejectOfferAsync to IOffersRepository and its implementation.
- Introduced DeclineOffer method in ClientService and IClientService.
- Added DeclineOfferResultDto for response data.
- Created POST cf/offers/decline endpoint in ClientController, with SignalR notification to technicians.
- Updated AcceptOffer exception messages to Arabic.
- Fixed GetRejectedTechnicianUserIds to use Pending status.