### PR TITLE
Add technician calendar feature with reservation details

### DIFF
--- a/el7erafe.Web/Core/DomainLayer/Contracts/IReservationRepository.cs
+++ b/el7erafe.Web/Core/DomainLayer/Contracts/IReservationRepository.cs
@@ -7,6 +7,7 @@ namespace DomainLayer.Contracts
     {
         Task AddAsync(Reservation reservation);
         Task<Reservation?> GetByOfferIdAsync(int offerId);
+        Task<List<Reservation>> GetCurrentReservationsAsync(int technicianId, DateTime date);
         Task SaveChangesAsync();
     }
 }

--- a/el7erafe.Web/Core/Service/TechnicianFlowService.cs
+++ b/el7erafe.Web/Core/Service/TechnicianFlowService.cs
@@ -6,11 +6,13 @@ using DomainLayer.Models.IdentityModule.Enums;
 using Microsoft.AspNetCore.Identity;
 using Service.Helpers;
 using ServiceAbstraction;
+using Shared.DataTransferObject.Calendar;
 using Shared.DataTransferObject.OffersDTOs;
 using Shared.DataTransferObject.OtpDTOs;
 using Shared.DataTransferObject.ServiceRequestDTOs;
 using Shared.DataTransferObject.TechnicianIdentityDTOs;
 using Shared.DataTransferObject.UpdateDTOs;
+using System;
 
 namespace Service
 {
@@ -20,7 +22,8 @@ namespace Service
         OtpHelper otpHelper,
         UserManager<ApplicationUser> userManager,
         IServiceRequestRepository serviceRequestRepository,
-        IOffersRepository offersRepository) : ITechnicianFlowService
+        IOffersRepository offersRepository,
+        IReservationRepository reservationRepository) : ITechnicianFlowService
     {
         public async Task<TechnicianProfileDTO> GetProfile(string userId)
         {
@@ -440,6 +443,58 @@ namespace Service
             }
 
             return result;
+        }
+
+        public async Task<List<TechnicianCalendarDto>> GetCalendar(string userId, DateTime? date)
+        {
+            var user = await CheckUser(userId);
+
+            var targetDate = date ?? DateTime.UtcNow;
+
+            var reservations = await reservationRepository.GetCurrentReservationsAsync(user.Id, targetDate);
+
+            reservations = reservations
+                .OrderBy(r => r.Offer.WorkFrom)
+                .ToList();
+
+            var tasks = reservations.Select(async reservation =>
+            {
+                var serviceURLsTask = blobStorageRepository
+                    .GetBlobUrlsWithPrefixAsync("service-requests-images", $"{reservation.Offer.Id}_");
+
+                var clientImageTask = blobStorageRepository
+                    .GetBlobUrlWithSasTokenAsync(
+                        "client-profilepics",
+                        reservation.Offer.ServiceRequest.Client?.ImageURL);
+
+                await Task.WhenAll(serviceURLsTask, clientImageTask);
+
+                return new TechnicianCalendarDto
+                {
+                    ReservationId = reservation.Id,
+
+                    Description = reservation.Offer.ServiceRequest.Description,
+
+                    ClientName = reservation.Offer.ServiceRequest.Client?.Name,
+                    ClientImage = clientImageTask.Result,
+
+                    TechTimeInterval = HelperClass.FormatArabicTimeInterval(
+                        reservation.Offer.WorkFrom,
+                        reservation.Offer.WorkTo),
+
+                    Day = reservation.Offer.ServiceRequest.ServiceDate,
+
+                    Governorate = reservation.Offer.ServiceRequest.City?.Governorate?.NameAr,
+                    City = reservation.Offer.ServiceRequest.City?.NameAr,
+                    Street = reservation.Offer.ServiceRequest.Street,
+
+                    ServiceImages = serviceURLsTask.Result,
+
+                    SpecialSign = reservation.Offer.ServiceRequest.SpecialSign
+                };
+            });
+
+            return (await Task.WhenAll(tasks)).ToList();
         }
 
         public async Task<Technician?> GetTechnicianByIdAsync(int techId)

--- a/el7erafe.Web/Core/ServiceAbstraction/ITechnicianFlowService.cs
+++ b/el7erafe.Web/Core/ServiceAbstraction/ITechnicianFlowService.cs
@@ -1,4 +1,5 @@
 ﻿using DomainLayer.Models.IdentityModule;
+using Shared.DataTransferObject.Calendar;
 using Shared.DataTransferObject.OffersDTOs;
 using Shared.DataTransferObject.OtpDTOs;
 using Shared.DataTransferObject.ServiceRequestDTOs;
@@ -19,6 +20,7 @@ namespace ServiceAbstraction
         Task<List<PendingOfferDto>> GetPendingOffersAsync(string technicianUserId);
         Task UpdateEmailAsync(string userId, OtpCodeDTO otpCode);
         Task<OtpResponseDTO> ResendOtpForPendingEmail(string userId);
+        Task<List<TechnicianCalendarDto>> GetCalendar(string userId, DateTime? date);
         Task DeleteAccount(string userId);
     }
 }

--- a/el7erafe.Web/Infrastructure/Persistance/Repositories/ReservationRepository.cs
+++ b/el7erafe.Web/Infrastructure/Persistance/Repositories/ReservationRepository.cs
@@ -1,5 +1,6 @@
 ﻿using DomainLayer.Contracts;
 using DomainLayer.Models;
+using DomainLayer.Models.IdentityModule.Enums;
 using Microsoft.EntityFrameworkCore;
 using Persistance.Databases;
 
@@ -16,6 +17,23 @@ namespace Persistance.Repositories
         {
             return await dbcontext.Reservations
                 .FirstOrDefaultAsync(r => r.OfferId == offerId);
+        }
+
+        public async Task<List<Reservation>> GetCurrentReservationsAsync(int technicianId, DateTime date)
+        {
+            var targetDate = DateOnly.FromDateTime(date);
+
+            return await dbcontext.Reservations
+                .Where(r =>
+                    r.Status == ReservationStatus.Confirmed &&
+                    r.Offer.TechnicianId == technicianId &&
+                    r.Offer.ServiceRequest.ServiceDate == targetDate
+                )
+                .Include(r => r.Offer)
+                    .ThenInclude(o => o.ServiceRequest)
+                        .ThenInclude(sr => sr.Client)
+                .Include(r => r.Offer.ServiceRequest.Service)
+                .ToListAsync();
         }
 
         public async Task SaveChangesAsync()

--- a/el7erafe.Web/Infrastructure/Presentation/Controllers/TechnicianFlowController.cs
+++ b/el7erafe.Web/Infrastructure/Presentation/Controllers/TechnicianFlowController.cs
@@ -203,7 +203,8 @@ namespace Presentation.Controllers
         }
 
         [HttpPost("make-offer")]
-        public async Task<IActionResult> MakeOffer(MakeOfferDto dto) {
+        public async Task<IActionResult> MakeOffer(MakeOfferDto dto)
+        {
             var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
             if (string.IsNullOrEmpty(userId))
                 return Unauthorized("المستخدم غير موجود");
@@ -227,6 +228,16 @@ namespace Presentation.Controllers
 
             var result = await technicianService.GetPendingOffersAsync(userId);
 
+            return Ok(result);
+        }
+
+        [HttpGet("calendar")]
+        public async Task<IActionResult> GetCalendar(DateTime? date)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrEmpty(userId))
+                return Unauthorized("المستخدم غير موجود");
+            var result = await technicianService.GetCalendar(userId, date ?? DateTime.Now);
             return Ok(result);
         }
     }

--- a/el7erafe.Web/Shared/DataTransferObject/Calendar/TechnicianCalendarDto.cs
+++ b/el7erafe.Web/Shared/DataTransferObject/Calendar/TechnicianCalendarDto.cs
@@ -1,0 +1,25 @@
+﻿
+namespace Shared.DataTransferObject.Calendar
+{
+    public class TechnicianCalendarDto
+    {
+        public int ReservationId { get; set; }
+
+        public string? ClientName { get; set; }
+        public string? ClientImage { get; set; }
+
+        public string? Description { get; set; }
+
+        public string? TechTimeInterval { get; set; }
+
+        public DateOnly? Day { get; set; }
+
+        public List<string>? ServiceImages { get; set; }
+
+        public string? Governorate { get; set; }
+        public string? City { get; set; }
+        public string? Street { get; set; }
+
+        public string? SpecialSign { get; set; }
+    }
+}


### PR DESCRIPTION
Technicians can now view their calendar of confirmed reservations for a specific date via a new GET /calendar endpoint. Introduced TechnicianCalendarDto to encapsulate reservation and client details. Added GetCurrentReservationsAsync to IReservationRepository and implemented it in ReservationRepository. Updated ITechnicianFlowService and TechnicianFlowService to provide the GetCalendar method, which aggregates reservation data and related images. Included necessary dependency injections and using statements to support the new functionality.