### PR TITLE
Add chat message moderation with regex and ML checks

### DIFF
--- a/el7erafe.Web/Core/DomainLayer/Contracts/IBlobStorageRepository.cs
+++ b/el7erafe.Web/Core/DomainLayer/Contracts/IBlobStorageRepository.cs
@@ -19,6 +19,7 @@ namespace DomainLayer.Contracts
             int expiryHours = 1);
         Task<int> CountBlobsWithPrefixAsync(string containerName, string prefix);
         Task<int> DeleteBlobsWithPrefixAsync(string containerName, string prefix);
+        Task AppendToReviewListAsync(string text, float conf, string label);
 
     }
 }

--- a/el7erafe.Web/Core/Service/Moderation/ModerationService.cs
+++ b/el7erafe.Web/Core/Service/Moderation/ModerationService.cs
@@ -1,0 +1,34 @@
+﻿using ServiceAbstraction.Moderation;
+using Shared.DataTransferObject.Moderation;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Service.Moderation
+{
+    public class ModerationService(HttpClient httpClient) : IModerationService
+    {
+        public async Task<ModerationResult> CheckMessageAsync(string content)
+        {
+            var response = await httpClient.PostAsJsonAsync(
+                "https://regex-container-app.purpleglacier-eba9becf.polandcentral.azurecontainerapps.io/moderate",
+                new { text = content }
+            );
+
+            var responseText = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+                throw new Exception($"Moderation service failed: {responseText}");
+
+            var result = JsonSerializer.Deserialize<ModerationResult>(
+                responseText,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true }
+            );
+
+            if (result == null)
+                throw new Exception("Invalid moderation response");
+
+            return result;
+        }
+    }
+}

--- a/el7erafe.Web/Core/Service/ServiceLayerServicesRegistiration.cs
+++ b/el7erafe.Web/Core/Service/ServiceLayerServicesRegistiration.cs
@@ -2,8 +2,10 @@
 using Service.Chat;
 using Service.Email;
 using Service.Helpers;
+using Service.Moderation;
 using ServiceAbstraction;
 using ServiceAbstraction.Chat;
+using ServiceAbstraction.Moderation;
 
 namespace Service
 {
@@ -32,6 +34,7 @@ namespace Service
             services.AddScoped<IOfferService, OfferService>();
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<INotificationService, NotificationService>();
+            services.AddHttpClient<IModerationService, ModerationService>();
             services.AddSignalR();
             return services;
         }

--- a/el7erafe.Web/Core/ServiceAbstraction/Moderation/IModerationService.cs
+++ b/el7erafe.Web/Core/ServiceAbstraction/Moderation/IModerationService.cs
@@ -1,0 +1,10 @@
+﻿
+using Shared.DataTransferObject.Moderation;
+
+namespace ServiceAbstraction.Moderation
+{
+    public interface IModerationService
+    {
+        Task<ModerationResult> CheckMessageAsync(string content);
+    }
+}

--- a/el7erafe.Web/Infrastructure/Persistance/BlobStorageRepository.cs
+++ b/el7erafe.Web/Infrastructure/Persistance/BlobStorageRepository.cs
@@ -1,10 +1,12 @@
 ﻿using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Sas;
 using DomainLayer.Contracts;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
+using System.Text;
 
 namespace Persistance
 {
@@ -12,7 +14,8 @@ namespace Persistance
                                        IUserDelegationKeyCache _userDelegationKeyCache,
                                        BlobServiceClient _blobServiceClient) : IBlobStorageRepository
     {
-
+        private readonly string _containerName = "ml-logs";
+        private readonly string _blobName = "review_queue.txt";
         public async Task<string> UploadFileAsync(IFormFile file, string containerName, string? customFileName = null)
         {
             // File validation
@@ -335,6 +338,28 @@ namespace Persistance
             }
 
             return deletedCount;
+        }
+
+        public async Task AppendToReviewListAsync(string text, float conf, string label)
+        {
+            // 1️ Get container
+            var containerClient = _blobServiceClient.GetBlobContainerClient(_containerName);
+
+            // 2️ Ensure container exists (safe)
+            await containerClient.CreateIfNotExistsAsync();
+
+            // 3️ Get append blob
+            var appendBlobClient = containerClient.GetAppendBlobClient(_blobName);
+
+            // 4️ Create if not exists
+            await appendBlobClient.CreateIfNotExistsAsync();
+
+            // 5️ Format log
+            string logEntry = $"{label} | {conf:P1} | {text}{Environment.NewLine}";
+
+            // 6️ Append
+            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(logEntry));
+            await appendBlobClient.AppendBlockAsync(ms);
         }
     }
 }

--- a/el7erafe.Web/Infrastructure/Presentation/Hubs/ChatHub.cs
+++ b/el7erafe.Web/Infrastructure/Presentation/Hubs/ChatHub.cs
@@ -1,9 +1,11 @@
-﻿using DomainLayer.Models.ChatModule.Enums;
+﻿using DomainLayer.Contracts;
+using DomainLayer.Models.ChatModule.Enums;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using ServiceAbstraction;
 using ServiceAbstraction.Chat;
+using ServiceAbstraction.Moderation;
 using Shared.DataTransferObject.ChatDTOs;
 using Shared.DataTransferObject.NotificationDTOs;
 using static Microsoft.EntityFrameworkCore.DbLoggerCategory.Database;
@@ -12,7 +14,9 @@ namespace Service.Hubs
 {
     [Authorize(AuthenticationSchemes = "Bearer", Roles = "Client,Technician")]
     public class ChatHub(IChatService _chatService,
-                         INotificationService notificationService) : Hub
+                         INotificationService notificationService,
+                         IModerationService moderationService,
+                         IBlobStorageRepository blobStorageRepository) : Hub
     {
         public override async Task OnConnectedAsync()
         {
@@ -81,6 +85,48 @@ namespace Service.Hubs
 
             if (string.IsNullOrEmpty(senderId))
                 throw new HubException("Unauthorized");
+
+            #region MODERATION_CHECK
+            var moderation = await moderationService.CheckMessageAsync(messageDto.Content);
+
+            if (!moderation.IsSafe)
+            {
+                // Regex layer fail
+                if (moderation.Layer == "regex")
+                {
+                    await Clients.Caller.SendAsync("MessageRejected", new
+                    {
+                        reason = moderation.Reason,
+                        layer = "regex"
+                    });
+                    return;
+                }
+
+                // ML layer fail
+                if (moderation.Layer == "machine_learning")
+                {
+                    bool highConfidence = (moderation.Confidence ?? 0) >= 0.7;
+
+                    await Clients.Caller.SendAsync("MessageRejected", new
+                    {
+                        reason = moderation.Reason,
+                        layer = "ml",
+                        confidence = moderation.Confidence
+                    });
+
+                    if (!highConfidence)
+                    {
+                        await blobStorageRepository.AppendToReviewListAsync(
+                            messageDto.Content,
+                            (float)(moderation.Confidence ?? 0),
+                            "__label__unsafe"
+                        );
+                    }
+
+                    return;
+                }
+            } 
+            #endregion
 
             // 1️ Save message
             var savedMessage = await _chatService.SendMessageAsync(messageDto, senderId);

--- a/el7erafe.Web/Shared/DataTransferObject/Moderation/ModerationResult.cs
+++ b/el7erafe.Web/Shared/DataTransferObject/Moderation/ModerationResult.cs
@@ -1,0 +1,17 @@
+﻿
+using System.Text.Json.Serialization;
+
+namespace Shared.DataTransferObject.Moderation
+{
+    public class ModerationResult
+    {
+        [JsonPropertyName("is_safe")]
+        public bool IsSafe { get; set; }
+        [JsonPropertyName("layer")]
+        public string Layer { get; set; } = default!;
+        [JsonPropertyName("reason")]
+        public string Reason { get; set; } = default!;
+        [JsonPropertyName("confidence")]
+        public double? Confidence { get; set; }
+    }
+}


### PR DESCRIPTION
Integrate a moderation layer for chat messages using both regex and machine learning checks before delivery. Add IModerationService and ModerationService to call an external moderation API and process ModerationResult responses. Reject unsafe messages and notify clients; if ML confidence is low, append messages to a review queue in Azure Blob Storage. Update service registration and dependency injection accordingly.