### PR TITLE
Remove SaveChangesAsync from CommitTransactionWithoutSaving

### DIFF
--- a/el7erafe.Web/Infrastructure/Persistance/Repositories/UnitOfWork.cs
+++ b/el7erafe.Web/Infrastructure/Persistance/Repositories/UnitOfWork.cs
@@ -24,7 +24,6 @@ namespace Persistance.Repositories
         {
             try
             {
-                await _context.SaveChangesAsync();
                 if (_currentTransaction != null)
                     await _currentTransaction.CommitAsync();
             }


### PR DESCRIPTION
CommitTransactionWithoutSavingChangesAsync no longer calls SaveChangesAsync, ensuring it only commits the transaction without persisting changes to the database context.