### PR TITLE
Refactor transaction commit to always save changes

### DIFF
--- a/el7erafe.Web/Core/DomainLayer/Contracts/IUnitOfWork.cs
+++ b/el7erafe.Web/Core/DomainLayer/Contracts/IUnitOfWork.cs
@@ -4,7 +4,7 @@ namespace DomainLayer.Contracts
     public interface IUnitOfWork
     {
         Task BeginTransactionAsync();
-        Task CommitTransactionWithoutSavingChangesAsync();
+        Task CommitTransactionAsync();
         Task RollbackTransactionAsync();
     }
 }

--- a/el7erafe.Web/Core/Service/ClientService.cs
+++ b/el7erafe.Web/Core/Service/ClientService.cs
@@ -167,7 +167,7 @@ namespace Service
                        "service-requests-images",
                        $"{createdRequest.Id}_{Guid.NewGuid()}");
 
-                    await unitOfWork.CommitTransactionWithoutSavingChangesAsync();
+                    await unitOfWork.CommitTransactionAsync();
                 }
                 catch
                 {
@@ -240,7 +240,7 @@ namespace Service
                 if (!deleted)
                     throw new TechnicalException();
 
-                await unitOfWork.CommitTransactionWithoutSavingChangesAsync();
+                await unitOfWork.CommitTransactionAsync();
             }
             catch
             {
@@ -453,7 +453,7 @@ namespace Service
                 if (!updateResult.Succeeded)
                     throw new TechnicalException();
 
-                await unitOfWork.CommitTransactionWithoutSavingChangesAsync();
+                await unitOfWork.CommitTransactionAsync();
             }
             catch (UnprocessableEntityException)
             {
@@ -980,7 +980,7 @@ namespace Service
 
                 await technicianRepository.UpdateTechnicianRatingAsync(technicianId, newAverage);
 
-                await unitOfWork.CommitTransactionWithoutSavingChangesAsync();
+                await unitOfWork.CommitTransactionAsync();
             }
             catch (Exception)
             {

--- a/el7erafe.Web/Core/Service/TechnicianFlowService.cs
+++ b/el7erafe.Web/Core/Service/TechnicianFlowService.cs
@@ -88,7 +88,7 @@ namespace Service
                         await blobStorageRepository.DeleteFileAsync(oldImageUrl, "technician-documents");
                     }
 
-                    await unitOfWork.CommitTransactionWithoutSavingChangesAsync();
+                    await unitOfWork.CommitTransactionAsync();
                 }
                 catch
                 {
@@ -231,7 +231,7 @@ namespace Service
                 if (!updateResult.Succeeded)
                     throw new TechnicalException();
 
-                await unitOfWork.CommitTransactionWithoutSavingChangesAsync();
+                await unitOfWork.CommitTransactionAsync();
             }
             catch (UnprocessableEntityException)
             {
@@ -289,7 +289,7 @@ namespace Service
                 if (deleted == 0)
                     throw new TechnicalException();
 
-                await unitOfWork.CommitTransactionWithoutSavingChangesAsync();
+                await unitOfWork.CommitTransactionAsync();
 
                 var blobDeleteTasks = new List<Task>();
 

--- a/el7erafe.Web/Infrastructure/Persistance/Repositories/UnitOfWork.cs
+++ b/el7erafe.Web/Infrastructure/Persistance/Repositories/UnitOfWork.cs
@@ -20,10 +20,11 @@ namespace Persistance.Repositories
             _currentTransaction = await _context.Database.BeginTransactionAsync();
         }
 
-        public async Task CommitTransactionWithoutSavingChangesAsync()
+        public async Task CommitTransactionAsync()
         {
             try
             {
+                await _context.SaveChangesAsync();
                 if (_currentTransaction != null)
                     await _currentTransaction.CommitAsync();
             }


### PR DESCRIPTION
Replaced CommitTransactionWithoutSavingChangesAsync with CommitTransactionAsync in IUnitOfWork and all usages. CommitTransactionAsync now saves changes before committing, ensuring data persistence within transactions. Removed the old method to simplify transaction handling.